### PR TITLE
Working 1.0.30 build

### DIFF
--- a/scripts/cpp_generator.py
+++ b/scripts/cpp_generator.py
@@ -436,7 +436,9 @@ class CppGenerator(AutomaticSourceOutputGenerator):
         null_atom = self.conventions.generate_structure_type_from_name(typename)
         name = null_atom.replace('XR_TYPE', 'XR_NULL')
         if not self.registry.reg.findall(f"types/type[name = '{name}']"):
-            return None
+            # Not all extensions define a NULL value for their atoms, so we have to fall back to a zero value.
+            # I'm looking at you XR_FB_spatial_entity
+            return '0'
         return name
 
     def findVendorSuffix(self, name):

--- a/scripts/hpp_genxr.py
+++ b/scripts/hpp_genxr.py
@@ -53,20 +53,23 @@ def endTimer(timeit: bool, msg: str):
         startTime = None
 
 
-def makeREstring(strings: Iterable[str], default: typing.Optional[str]=None) -> str:
+def makeREstring(strings: Iterable[str], default: typing.Optional[str] = None) -> str:
     """Turn a list of strings into a regexp string matching exactly those strings."""
     if strings or default is None:
         return '^(' + '|'.join((re.escape(s) for s in strings)) + ')$'
     return default
 
+
 errWarn: typing.TextIO = sys.stderr
 diag: typing.TextIO = None
+
 
 def get_headers() -> typing.List[str]:
     lines = []
     with open(os.path.join('headers.txt'), 'r', encoding='utf-8') as f:
-        lines = [ line.strip() for line in f.readlines() if re.match('^openxr.*', line) is not None ]
+        lines = [line.strip() for line in f.readlines() if re.match('^openxr.*', line) is not None]
     return lines
+
 
 def genTarget(args) -> typing.Tuple[CppGenerator, AutomaticSourceGeneratorOptions]:
     """
@@ -252,8 +255,6 @@ def generateHeader(args, header):
         outputfile = os.path.join(args.directory, options.filename)
         subprocess.run(['clang-format', '-style=file', '-i', outputfile])
 
-# Keeping this at the bottom so all function defintitions are in scope by the time it runs
-# If we left it where main() is now, then when main calls generateHeader(), it would fail
-# Conversely if I move generateHader() earlier, then the git diff wouldn't show it as unchanged
+
 if __name__ == '__main__':
     main()

--- a/scripts/template_openxr_handles_forward.hpp
+++ b/scripts/template_openxr_handles_forward.hpp
@@ -57,6 +57,10 @@ namespace traits {
 class DispatchLoaderStatic;
 class DispatchLoaderDynamic;
 
+// FIXME a hack to get this working, since I don't know how to appropriately force the code to not project the
+// XrSpaceUserIdFB name, and I don't want to make a openxr_spaceuseridfb.hpp file just for this.
+using SpaceUserIdFB = XrSpaceUserIdFB;
+
 //# for handle in gen.api_handles
 //## Note this won't actually find anything until automatic_source_generator.py is modified
 //## to actually store a value under "alias" for handles, but...

--- a/scripts/template_openxr_structs_forward.hpp
+++ b/scripts/template_openxr_structs_forward.hpp
@@ -41,13 +41,14 @@
 namespace OPENXR_HPP_NAMESPACE {
 
 //# for struct in gen.api_structures
-//#     if struct.alias
-using /*{ project_type_name(struct.name) }*/ = /*{ project_type_name(struct.alias) }*/;
-//#     else
 struct /*{project_type_name(struct.name)}*/;
-//#     endif
 //# endfor
 
+//# for k,v in gen.aliases.items()
+//# if v in gen.dict_structs
+using /*{ project_type_name(k) }*/ = /*{ project_type_name(v) }*/;
+//# endif
+//# endfor
 }  // namespace OPENXR_HPP_NAMESPACE
 
 //# include('file_footer.hpp')


### PR DESCRIPTION
Fix several bugs blocking generation of valid C++ bindings

Targeting #39 as well as some other issues related to lines in the XR registry like this: 
```
        <type category="struct" name="XrDevicePcmSampleRateGetInfoFB" alias="XrDevicePcmSampleRateStateFB"/>
```

This _should_ generate a `using DevicePcmSampleRateStateFB = DevicePcmSampleRateGetInfoFB;` line in the structs file, but doesn't, so functions returning the `DevicePcmSampleRateStateFB` fail to compile.
