### PR TITLE
OpenXR SDK 1.1.57 compatibility

### DIFF
--- a/OPENXR-HPP.md
+++ b/OPENXR-HPP.md
@@ -174,6 +174,10 @@ xr::Swapchain swapchain =
                               1});
 ```
 
+Because of the strict C++ naming rule, a sub-class can't change a parent class
+member name; so in very rare cases the sub-class keep the parent member name
+(e.g. XrCompositionLayerPassthroughFB.flags become XrCompositionLayerPassthroughFB.layerFlags).
+
 ### Return values, Error Codes & Exceptions
 
 By default OpenXR-Hpp has exceptions enabled. This means that OpenXR-Hpp checks

--- a/OPENXR-HPP.md
+++ b/OPENXR-HPP.md
@@ -311,7 +311,35 @@ into the dispatch object every time it's called. While not an issue for
 infrequently called functions, if executed inside a loop or on a per-frame
 basis, this can adversely impact performance.
 
-Note that this can be configured.
+However, you can define a global dynamic dispatcher, e.g. :
+
+in file pch.h :
+```c++
+// ...
+#include <openxr/openxr.h>
+#include <openxr/openxr_platform.h>
+#include <openxr/openxr_reflection.h>
+#include <openxr/openxr_dispatch_dynamic.hpp>
+extern xr::DispatchLoaderDynamic globalDispatchLoaderDynamic;
+#define OPENXR_HPP_DEFAULT_EXTENSION_DISPATCHER_TYPE xr::DispatchLoaderDynamic
+#define OPENXR_HPP_DEFAULT_EXTENSION_DISPATCHER std::move(::globalDispatchLoaderDynamic)
+#include <openxr/openxr.hpp>
+// ...
+```
+
+in file pch.cpp :
+```c++
+#include "pch.h"
+xr::DispatchLoaderDynamic globalDispatchLoaderDynamic;
+```
+
+then in your code :
+```c++
+#include "pch.h"
+// ...
+xr::DebugUtilsMessengerEXT messenger =
+    instance.createDebugUtilsMessengerEXT({ severityFlags, typeFlags, debugCallback, userData });
+```
 
 @see config_dispatch
 

--- a/OPENXR-HPP.md
+++ b/OPENXR-HPP.md
@@ -41,6 +41,10 @@ The following additional naming conventions apply
     * `XR_DEBUG_UTILS_MESSAGE_SEVERITY_VERBOSE_BIT_EXT` is now
       `xr::DebugUtilsMessageSeverityFlagBitsEXT::Verbose`. (Type is an
       extension, so removed from value.)
+  * Note: to avoid compilation error, if the enum identifier start 
+    with a digit, it has an underscore prefix :
+      e.g. XR_MARKER_ARUCO_DICT_4X4_50_ML become xr::MarkerArucoDictML:_4X4_50
+           (and not xr::MarkerArucoDictML:4X4_50)
 * Flag bits are handled like enums with the addition that the `_BIT` suffix has
   also been removed.
   * `XR_SPACE_VELOCITY_LINEAR_VALID_BIT` is now

--- a/OPENXR-HPP.md
+++ b/OPENXR-HPP.md
@@ -345,6 +345,42 @@ xr::DebugUtilsMessengerEXT messenger =
 
 ### Samples
 
+## Incompatibilities
+
+A few modifications introduced some minor incompatibilities :
+
+* pseudo native C type projection 
+* replace XrViewState and XrView with xr::viewState and xr::view.
+
+which meens that in some functions calls you must replace OpenXR type
+pointer with OpenXR-HPP type reference, and some basic C type (as
+std::uint32_t) pointers with references.
+
+You can revert to the previous behaviour by commenting lines in the
+scripts/data.py file :
+
+```c++
+PROJECTED_NATIVE_C_TYPE = set((
+## stop C type projection (pointer -> reference)
+#    "int8_t",
+#    "int32_t",
+#    "int64_t",
+#    "uint8_t",
+#    "uint32_t",
+#    "uint64_t",
+#    "float",
+#    "XrSpaceUserIdFB",
+))
+
+SKIP_PROJECTION = set((
+    "XrBaseInStructure",
+    "XrBaseOutStructure",
+## unproject few OpenXR types
+#    "XrViewState",
+#    "XrView",
+))
+```
+
 ## See Also
 
 ## Credits

--- a/OPENXR-HPP.md
+++ b/OPENXR-HPP.md
@@ -376,8 +376,8 @@ SKIP_PROJECTION = set((
     "XrBaseInStructure",
     "XrBaseOutStructure",
 ## unproject few OpenXR types
-#    "XrViewState",
-#    "XrView",
+    "XrViewState",
+    "XrView",
 ))
 ```
 

--- a/scripts/cpp_generator.py
+++ b/scripts/cpp_generator.py
@@ -438,6 +438,9 @@ class CppGenerator(AutomaticSourceOutputGenerator):
         if suffix:
             enum_name += suffix
 
+        if enum_name[0].isdigit():
+            enum_name = "_" + enum_name
+ 
         return enum_name
 
     def get_flag_value_prefix_suffix(self, typename):

--- a/scripts/cpp_generator.py
+++ b/scripts/cpp_generator.py
@@ -567,8 +567,16 @@ class CppGenerator(AutomaticSourceOutputGenerator):
                 continue
             name = param.name
             cpp_type = _project_type_name(param.type)
-            method.decl_dict[name] = f"{cpp_type} {name}"
-            method.access_dict[name] = f"{name.strip()}.get()"
+            if param.pointer_count == 1 and not param.is_const:
+               if param.pointer_count_var != '':
+                   method.decl_dict[name] = f"{cpp_type}* {name}"
+                   method.access_dict[name] = f"{name.strip()}->put()"
+               else:
+                   method.decl_dict[name] = f"{cpp_type}& {name}"
+                   method.access_dict[name] = f"{name.strip()}.put()"
+            else:
+                method.decl_dict[name] = f"{cpp_type} {name}"
+                method.access_dict[name] = f"{name.strip()}.get()"
 
     def _update_enhanced_return_type(self, method):
         """Set the return type based on the bare return type.
@@ -762,7 +770,7 @@ class CppGenerator(AutomaticSourceOutputGenerator):
             if param.pointer_count > 0 and not param.is_const:
                 return False
 
-        # if not self.quiet:
+        #if not self.quiet:
         #     print(f"method {method.name} has output parameter {last_param.name} of type {last_param.type}")
         return True
 

--- a/scripts/cpp_generator.py
+++ b/scripts/cpp_generator.py
@@ -102,7 +102,12 @@ def _project_type_name(typename):
 
 
 def _is_static_length_array(member):
-    return member.is_array and member.pointer_count == 0
+    is_static_length_array = member.is_array and member.pointer_count == 0
+    if is_static_length_array and member.array_count_var == '':
+        size_begin = member.cdecl.find("[")
+        size_end = member.cdecl.find("]", size_begin)
+        member.array_count_var = member.cdecl[size_begin + 1:size_end]
+    return is_static_length_array
 
 
 def _is_static_length_string(member):

--- a/scripts/cpp_generator.py
+++ b/scripts/cpp_generator.py
@@ -1025,6 +1025,7 @@ class CppGenerator(AutomaticSourceOutputGenerator):
             self.dict_enums[enum.name] = enum
 
         result_enum = self.dict_enums['XrResult']
+        result_enum.values = [value for value in result_enum.values if not value.alias]
 
         for struct in self.api_structures:
             self.dict_structs[struct.name] = struct

--- a/scripts/cpp_generator.py
+++ b/scripts/cpp_generator.py
@@ -743,7 +743,8 @@ class CppGenerator(AutomaticSourceOutputGenerator):
             return False
 
         last_param = method.params[-1]
-        if last_param.is_const or last_param.pointer_count != 1 or last_param.array_count_var != '':
+        last_param_struct = self.dict_structs.get(last_param.type)
+        if last_param.is_const or last_param.pointer_count != 1 or last_param.array_count_var != '' or (last_param_struct and self._is_base_only(last_param_struct)):
             return False
 
         # Do not return a single output of a type we aren't projecting

--- a/scripts/cpp_generator.py
+++ b/scripts/cpp_generator.py
@@ -993,7 +993,7 @@ class CppGenerator(AutomaticSourceOutputGenerator):
             if member.type == 'char' and member.is_array and member.pointer_count == 0:
                 # We'll initialize a fixed-size string with a cstring.
                 result = f"const char* {member.name}{suffix}"
-            elif member.type.startswith("Xr") and member.pointer_count == 0:
+            elif member.type.startswith("Xr") and not member.is_array and member.pointer_count == 0:
                 result = f"const {_project_type_name(member.type)}& {member.name}{suffix}"
 
         if defaulted:

--- a/scripts/cpp_generator.py
+++ b/scripts/cpp_generator.py
@@ -1013,6 +1013,19 @@ class CppGenerator(AutomaticSourceOutputGenerator):
         if self.isCoreExtensionName(extname):
             return False
         return self.dict_extensions[extname].protect_value is not None
+        
+    def topologic_sort(self, api_list):
+        # Don't use iterators because we move items in place while scanning and searching
+        index = 0
+        while index < len(api_list):
+            parent = self.struct_parents.get(api_list[index].name)
+            if (parent):
+               for depend in range(index + 1, len(api_list)):
+                  if api_list[depend].name == parent:
+                     api_list.insert(index, api_list.pop(depend))
+                     index += 1
+                     break
+            index += 1
 
     # Write out all the information for the appropriate file,
     # and then call down to the base class to wrap everything up.
@@ -1034,7 +1047,7 @@ class CppGenerator(AutomaticSourceOutputGenerator):
 
         for struct in self.api_structures:
             self.dict_structs[struct.name] = struct
-
+            
         for bitmask in self.api_bitmasks:
             self.dict_bitmasks[bitmask.name] = bitmask
 
@@ -1108,6 +1121,9 @@ class CppGenerator(AutomaticSourceOutputGenerator):
                 else:
                     # assumption violated
                     assert False
+
+        self.topologic_sort(self.api_structures)
+
         # Verify
         self.selftests()
 

--- a/scripts/cpp_generator.py
+++ b/scripts/cpp_generator.py
@@ -599,13 +599,13 @@ class CppGenerator(AutomaticSourceOutputGenerator):
     def _is_tagged_type(self, typename):
         if typename not in self.dict_structs:
             return False
-        return any((x.name == "type" for x in self.dict_structs[typename].members))
+        return any((x.name == "type" and x.type == "XrStructureType" for x in self.dict_structs[typename].members))
 
     def _get_tag(self, typename):
         if typename not in self.dict_structs:
             return None
         tag_member = [x for x in self.dict_structs[typename].members
-                      if x.name == "type"]
+                      if x.name == "type" and x.type == "XrStructureType"]
         if not tag_member:
             return None
         raw_tag = tag_member[0].values
@@ -884,13 +884,13 @@ class CppGenerator(AutomaticSourceOutputGenerator):
     def _is_base_only(self, struct):
         if not struct:
             return False
-        tag_member = [x for x in struct.members if x.name == "type"]
+        tag_member = [x for x in struct.members if x.name == "type" and x.type == "XrStructureType"]
         if not tag_member:
             return False
         return tag_member[0].values is None
 
     def _cpp_hidden_member(self, member):
-        return member.name == "type" or (member.name == "next" and member.type == "void")
+        return (member.name == "type" and member.type == "XrStructureType") or (member.name == "next" and member.type == "void")
 
     def _struct_member_count(self, struct):
         return len(struct.members)

--- a/scripts/cpp_generator.py
+++ b/scripts/cpp_generator.py
@@ -22,7 +22,7 @@ from typing import Optional
 from automatic_source_generator import AutomaticSourceOutputGenerator, write
 from data import (DISCOURAGED, 
                   PROJECTED_NATIVE_C_TYPE, MANUALLY_PROJECTED, MANUALLY_PROJECTED_SCALARS,
-                  SKIP, SKIP_PROJECTION, SPECIAL_TOKENS, TEMPLATED_TWO_CALL,
+                  SKIP, SKIP_PROJECTION, SPECIAL_TOKENS,
                   UPPER_TOKENS, VALID_FOR_NULL_INSTANCE)
 from jinja_helpers import JinjaTemplate, make_jinja_environment
 
@@ -501,8 +501,6 @@ class CppGenerator(AutomaticSourceOutputGenerator):
             method.is_member_function = True
             method.decl_dict[handle.name] = None
             method.access_dict[handle.name] = "this->get()"
-            # if method.cpp_name.endswith(method.cpp_handle):
-            #     method.cpp_name = _strip_suffix(method.cpp_name, method.cpp_handle)
 
         for param in method.decl_params:
             if param.type in SKIP_PROJECTION:
@@ -742,21 +740,11 @@ class CppGenerator(AutomaticSourceOutputGenerator):
 
         item_type_cpp = _project_type_name(item_type)
         method.item_type_cpp = item_type_cpp
-        templated = method.name in TEMPLATED_TWO_CALL
-        method.templated = templated
-
         vector_member_type = item_type_cpp
-        if templated:
-            vector_member_type = 'ResultItemType'
-
         vec_type = f"std::vector<{vector_member_type}, Allocator>"
         method.vec_type = vec_type
         method.template_decl_list.insert(0, f"typename Allocator = std::allocator<{vector_member_type}>")
         method.template_defn_list.insert(0, "typename Allocator")
-
-        if templated:
-            method.template_decl_list.insert(0, "typename ResultItemType")
-            method.template_defn_list.insert(0, "typename ResultItemType")
 
         method.capacity_input_param_name = capacity_input_param_name
         method.count_output_param_name = count_output_param_name
@@ -805,8 +793,6 @@ class CppGenerator(AutomaticSourceOutputGenerator):
             if param.pointer_count > 0 and not param.is_const:
                 return False
 
-        #if not self.quiet:
-        #     print(f"method {method.name} has output parameter {last_param.name} of type {last_param.type}")
         return True
 
     def _enhanced_method_projection(self, method):
@@ -883,7 +869,6 @@ class CppGenerator(AutomaticSourceOutputGenerator):
         method.post_statements.append('ObjectDestroy<impl::RemoveRefConst<Dispatch>> deleter{d};')
         method.handle_return_type = method.bare_return_type
         method.bare_return_type = f"UniqueHandle<{method.bare_return_type}, impl::RemoveRefConst<Dispatch>>"
-        # method.returns[1] = "{}({}, {})"
         self._update_enhanced_return_type(method)
 
     def _append_to_method_name_before_vendor(self, method, s):
@@ -1225,9 +1210,3 @@ class CppGenerator(AutomaticSourceOutputGenerator):
         assert not self._is_struct_output(self.dict_structs['XrApplicationInfo'])
 
         assert self._index0_of_first_visible_defaultable_member(self.dict_structs['XrApplicationInfo'], self.dict_structs['XrApplicationInfo'].members) == 0
-        # index = self._index0_of_first_visible_defaultable_member(self.dict_structs['XrInstanceCreateInfo'].members)
-        # print(index)
-        # assert(self._index0_of_first_visible_defaultable_member(self.dict_structs['XrInstanceCreateInfo'].members) == 0)
-        # members = self.dict_structs['XrInstanceCreateInfo'].members
-        # for i, member in enumerate(members):
-        #     print(i, member.name, self._is_member_defaultable(member))

--- a/scripts/cpp_generator.py
+++ b/scripts/cpp_generator.py
@@ -1086,7 +1086,7 @@ class CppGenerator(AutomaticSourceOutputGenerator):
             self.dict_bitmasks[bitmask.name] = bitmask
 
         for basetype in self.api_base_types:
-            if basetype.type == "XR_DEFINE_ATOM":
+            if basetype.type == "XR_DEFINE_ATOM" or basetype.type == "XR_DEFINE_OPAQUE_64":
                 self.dict_atoms[basetype.name] = basetype
 
         self.projected_types = MANUALLY_PROJECTED.union(self.dict_handles.keys())

--- a/scripts/cpp_generator.py
+++ b/scripts/cpp_generator.py
@@ -699,6 +699,11 @@ class CppGenerator(AutomaticSourceOutputGenerator):
             # If we're missing at least one, stop checking two-call stuff here.
             return False
 
+        last_param_struct = self.dict_structs.get(array_param['param'].type)
+        if self._is_base_only(last_param_struct):
+            # If this is a base type, we don't know what real type to allocate for the vector
+            return False;
+
         method.is_two_call = True
         method.masks_simple = False
         # Should we put "ToVector" on the method name?

--- a/scripts/cpp_generator.py
+++ b/scripts/cpp_generator.py
@@ -547,6 +547,10 @@ class CppGenerator(AutomaticSourceOutputGenerator):
                 # Input struct
                 method.decl_dict[name] = f"const {cpp_type}& {name}"
                 method.access_dict[name] = f"{name_stripped}.get()"
+            elif param.pointer_count == 0:
+                # Input struct passed by value
+                method.decl_dict[name] = f"{cpp_type} {name}"
+                method.access_dict[name] = f"{name_stripped}" # auto cast by specific structure static_cast operator
             elif param.pointer_count == 1:
                 # Output struct
                 if param.pointer_count_var != '':
@@ -560,6 +564,10 @@ class CppGenerator(AutomaticSourceOutputGenerator):
                        method.access_dict[name] = f"{name_stripped}.put(false)"
                     else:
                        method.access_dict[name] = f"{name_stripped}.put()"
+            elif param.pointer_count == 2:
+                # Output struct array
+                method.decl_dict[name] = f"{cpp_type}*& {name}"
+                method.access_dict[name] = f"reinterpret_cast<{param.type}**>(&{name_stripped})"
 
         # Convert atoms, plus XrTime and XrDuration as special case (promoted from raw ints to constexpr wrapper classes)
         for param in method.decl_params:

--- a/scripts/cpp_generator.py
+++ b/scripts/cpp_generator.py
@@ -885,7 +885,7 @@ class CppGenerator(AutomaticSourceOutputGenerator):
         return tag_member[0].values is None
 
     def _cpp_hidden_member(self, member):
-        return member.name == "type" or member.name == "next"
+        return member.name == "type" or (member.name == "next" and member.type == "void")
 
     def _struct_member_count(self, struct):
         return len(struct.members)
@@ -897,7 +897,7 @@ class CppGenerator(AutomaticSourceOutputGenerator):
         if struct.name.startswith("XrEventData"):
             return False
         nextptr = [x.cdecl for x in struct.members
-                   if x.name == 'next']
+                   if (x.name == 'next' and x.type == 'void')]
         return nextptr and 'const' in nextptr[0]
 
     def _is_struct_output(self, struct):
@@ -906,7 +906,7 @@ class CppGenerator(AutomaticSourceOutputGenerator):
         if struct.name.startswith("XrEventData"):
             return True
         nextptr = [x.cdecl for x in struct.members
-                   if x.name == 'next']
+                   if (x.name == 'next' and x.type == 'void')]
         if not nextptr:
             return False
         return 'const' not in nextptr[0]

--- a/scripts/cpp_generator.py
+++ b/scripts/cpp_generator.py
@@ -218,6 +218,12 @@ class StructProjection:
             return "next_"
         return None
 
+    @property
+    def alignas_spec(self):
+        if self.parent_type == "XrFutureCompletionBaseHeaderEXT":
+            return "\n#ifdef _WIN64\nalignas(void*)\n#endif\n"
+        return ""
+
 
 DISPATCH_TEMPLATE_PARAM_NAME = "Dispatch"
 DISPATCH_TEMPLATE_DEFN = f"typename {DISPATCH_TEMPLATE_PARAM_NAME}"

--- a/scripts/cpp_generator.py
+++ b/scripts/cpp_generator.py
@@ -725,10 +725,6 @@ class CppGenerator(AutomaticSourceOutputGenerator):
             # If we're missing at least one, stop checking two-call stuff here.
             return False
 
-        last_param_struct = self.dict_structs.get(array_param['param'].type)
-        if self._is_base_only(last_param_struct):
-            # If this is a base type, we don't know what real type to allocate for the vector
-            return False;
 
         method.is_two_call = True
         method.masks_simple = False
@@ -740,11 +736,22 @@ class CppGenerator(AutomaticSourceOutputGenerator):
 
         item_type_cpp = _project_type_name(item_type)
         method.item_type_cpp = item_type_cpp
+        last_param_struct = self.dict_structs.get(array_param['param'].type)
+        templated = self._is_base_only(last_param_struct)
+        method.templated = templated
+        
         vector_member_type = item_type_cpp
+        if templated:
+            vector_member_type = 'ResultItemType'
+
         vec_type = f"std::vector<{vector_member_type}, Allocator>"
         method.vec_type = vec_type
         method.template_decl_list.insert(0, f"typename Allocator = std::allocator<{vector_member_type}>")
         method.template_defn_list.insert(0, "typename Allocator")
+
+        if templated:
+            method.template_decl_list.insert(0, "typename ResultItemType")
+            method.template_defn_list.insert(0, "typename ResultItemType")
 
         method.capacity_input_param_name = capacity_input_param_name
         method.count_output_param_name = count_output_param_name

--- a/scripts/data.py
+++ b/scripts/data.py
@@ -38,6 +38,17 @@ MANUALLY_PROJECTED = set((
     "XrEventDataBuffer",
 )).union(MANUALLY_PROJECTED_SCALARS)
 
+PROJECTED_NATIVE_C_TYPE = set((
+    "int8_t",
+    "int32_t",
+    "int64_t",
+    "uint8_t",
+    "uint32_t",
+    "uint64_t",
+    "float",
+    "XrSpaceUserIdFB",
+))
+
 SKIP_PROJECTION = set((
     "XrBaseInStructure",
     "XrBaseOutStructure",

--- a/scripts/data.py
+++ b/scripts/data.py
@@ -14,6 +14,10 @@ EXCLUDED_EXTENSIONS = (
     # Projection of UuidMSFT fails
     "XR_MSFT_scene_understanding",
     "XR_MSFT_scene_understanding_serialization",
+    # Projection of derivated structure that failed to call their base classes
+    "XR_FB_passthrough",
+    "XR_META_passthrough_layer_resumed_event",
+    "XR_META_passthrough_color_lut",
 )
 
 

--- a/scripts/data.py
+++ b/scripts/data.py
@@ -15,12 +15,7 @@ EXCLUDED_EXTENSIONS = (
     "XR_MSFT_scene_understanding",
     "XR_MSFT_scene_understanding_serialization",
     # Ordering base to derivated class
-    "XR_ML_spatial_anchors",
-    "XR_ML_spatial_anchors_storage",
-    "XR_BD_spatial_scene",
     "XR_BD_spatial_sensing",
-    "XR_BD_spatial_anchor",
-    "XR_BD_spatial_anchor_sharing",
 )
 
 

--- a/scripts/data.py
+++ b/scripts/data.py
@@ -14,8 +14,6 @@ EXCLUDED_EXTENSIONS = (
     # Projection of UuidMSFT fails
     "XR_MSFT_scene_understanding",
     "XR_MSFT_scene_understanding_serialization",
-    # Ordering base to derivated class
-    "XR_BD_spatial_sensing",
 )
 
 

--- a/scripts/data.py
+++ b/scripts/data.py
@@ -14,8 +14,6 @@ EXCLUDED_EXTENSIONS = (
     # Projection of UuidMSFT fails
     "XR_MSFT_scene_understanding",
     "XR_MSFT_scene_understanding_serialization",
-    # Projection of derivated structure that failed to call their base classes
-    "XR_FB_passthrough",
     "XR_META_passthrough_layer_resumed_event",
     "XR_META_passthrough_color_lut",
     # Ordering base to derivated class

--- a/scripts/data.py
+++ b/scripts/data.py
@@ -18,6 +18,9 @@ EXCLUDED_EXTENSIONS = (
     "XR_FB_passthrough",
     "XR_META_passthrough_layer_resumed_event",
     "XR_META_passthrough_color_lut",
+    # Ordering base to derivated class
+    "XR_ML_spatial_anchors",
+    "XR_ML_spatial_anchors_storage",
 )
 
 

--- a/scripts/data.py
+++ b/scripts/data.py
@@ -14,8 +14,6 @@ EXCLUDED_EXTENSIONS = (
     # Projection of UuidMSFT fails
     "XR_MSFT_scene_understanding",
     "XR_MSFT_scene_understanding_serialization",
-    "XR_META_passthrough_layer_resumed_event",
-    "XR_META_passthrough_color_lut",
     # Ordering base to derivated class
     "XR_ML_spatial_anchors",
     "XR_ML_spatial_anchors_storage",

--- a/scripts/data.py
+++ b/scripts/data.py
@@ -21,6 +21,10 @@ EXCLUDED_EXTENSIONS = (
     # Ordering base to derivated class
     "XR_ML_spatial_anchors",
     "XR_ML_spatial_anchors_storage",
+    "XR_BD_spatial_scene",
+    "XR_BD_spatial_sensing",
+    "XR_BD_spatial_anchor",
+    "XR_BD_spatial_anchor_sharing",
 )
 
 

--- a/scripts/data.py
+++ b/scripts/data.py
@@ -24,10 +24,6 @@ DISCOURAGED = set((
     'xrStructureTypeToString',
 ))
 
-TEMPLATED_TWO_CALL = set([
-#    'xrEnumerateSwapchainImages'
-])
-
 MANUALLY_PROJECTED_SCALARS = set((
     "XrTime",
     "XrDuration",

--- a/scripts/data.py
+++ b/scripts/data.py
@@ -25,7 +25,7 @@ DISCOURAGED = set((
 ))
 
 TEMPLATED_TWO_CALL = set([
-    'xrEnumerateSwapchainImages'
+#    'xrEnumerateSwapchainImages'
 ])
 
 MANUALLY_PROJECTED_SCALARS = set((

--- a/scripts/data.py
+++ b/scripts/data.py
@@ -5,15 +5,6 @@
 """Collections of strings and names that affect the projection generation."""
 
 EXCLUDED_EXTENSIONS = (
-    # Atom not projecting right?
-    "XR_MSFT_controller_model",
-    # Projection of static string fails
-    "XR_MSFT_spatial_graph_bridge",
-    "XR_MSFT_spatial_anchor_persistence",
-    "XR_MSFT_holographic_window_attachment",
-    # Projection of UuidMSFT fails
-    "XR_MSFT_scene_understanding",
-    "XR_MSFT_scene_understanding_serialization",
 )
 
 
@@ -26,8 +17,6 @@ VALID_FOR_NULL_INSTANCE = set((
 
 # These break the projection right now.
 SKIP = set((
-    'xrGetSceneComputeStateMSFT',
-    'xrGetSwapchainStateFB',
 ))
 
 DISCOURAGED = set((
@@ -51,8 +40,6 @@ MANUALLY_PROJECTED = set((
 SKIP_PROJECTION = set((
     "XrBaseInStructure",
     "XrBaseOutStructure",
-    # Array of XrColor4f not getting initialized right
-    "XrPassthroughColorMapMonoToRgbaFB",
 ))
 
 UPPER_TOKENS = set((

--- a/scripts/data.py
+++ b/scripts/data.py
@@ -31,6 +31,7 @@ TEMPLATED_TWO_CALL = set([
 MANUALLY_PROJECTED_SCALARS = set((
     "XrTime",
     "XrDuration",
+    "XrBool32",
 ))
 
 MANUALLY_PROJECTED = set((

--- a/scripts/data.py
+++ b/scripts/data.py
@@ -48,6 +48,7 @@ PROJECTED_NATIVE_C_TYPE = set((
 SKIP_PROJECTION = set((
     "XrBaseInStructure",
     "XrBaseOutStructure",
+    "XrSpatialAnchorCreateCompletionBD",
 ))
 
 UPPER_TOKENS = set((

--- a/scripts/data.py
+++ b/scripts/data.py
@@ -32,6 +32,7 @@ MANUALLY_PROJECTED_SCALARS = set((
 
 MANUALLY_PROJECTED = set((
     "XrEventDataBuffer",
+    "XrFutureCompletionBaseHeaderEXT",
 )).union(MANUALLY_PROJECTED_SCALARS)
 
 PROJECTED_NATIVE_C_TYPE = set((
@@ -48,7 +49,6 @@ PROJECTED_NATIVE_C_TYPE = set((
 SKIP_PROJECTION = set((
     "XrBaseInStructure",
     "XrBaseOutStructure",
-    "XrSpatialAnchorCreateCompletionBD",
 ))
 
 UPPER_TOKENS = set((

--- a/scripts/enum.hpp
+++ b/scripts/enum.hpp
@@ -44,7 +44,7 @@
 //# endif
 //! @xrentity{/*{ enum.name }*/}
 //# endfilter
-enum class /*{projected_type -}*/ : int32_t {
+enum class /*{projected_type -}*/ {
 //# for val in enum.values
     /*{ protect_begin(val, enum) }*/
     /*{create_enum_value(val.name, enum.name)}*/ = /*{val.name}*/,
@@ -63,6 +63,18 @@ enum class /*{projected_type -}*/ : int32_t {
 //# endfilter
 OPENXR_HPP_INLINE OPENXR_HPP_CONSTEXPR /*{enum.name}*/ get(/*{projected_type}*/ const& v) {
     return static_cast</*{enum.name}*/>(v);
+}
+
+//! @addtogroup utility_accessors
+//! @{
+//# filter block_doxygen_comment
+//! @brief Free function for retrieving the raw /*{enum.name}*/ address from a /*{projected_type}*/.
+//!
+//! @found_by_adl
+//! @see /*{projected_type}*/
+//# endfilter
+OPENXR_HPP_INLINE /*{enum.name}*/ * put(/*{projected_type}*/ &v) {
+    return reinterpret_cast</*{enum.name}*/*>(&v);
 }
 
 //# filter block_doxygen_comment

--- a/scripts/struct.hpp
+++ b/scripts/struct.hpp
@@ -210,6 +210,15 @@
             }
             return reinterpret_cast</*{ struct.name }*/*>(this);
         }
+//# else
+//#     filter block_doxygen_comment
+        //! @brief Accessor for passing this as the address of a raw /*{struct.name}*/.
+        //!
+        //! The optional clear argument is not used in this abstract class
+//# endfilter
+        /*{ struct.name }*/ * put([[maybe_unused]] bool clear = true) noexcept {
+            return reinterpret_cast</*{ struct.name }*/*>(this);
+        }
 //# endif
 
 //# for member in struct.members if not member is cpp_hidden_member 
@@ -229,22 +238,19 @@
         return s.get();
     }
 
-//# if not s.is_abstract
-//#     filter block_doxygen_comment
+//# filter block_doxygen_comment
     //! @brief Free function accessor for clearing (by default) and passing /*{s.cpp_name}*/ as the address of a raw /*{struct.name}*/
     //! @relates /*{s.cpp_name}*/
     //! @ingroup utility_accessors
 //# endfilter
     static OPENXR_HPP_INLINE /*{ struct.name }*/ * put(/*{s.cpp_name}*/ &s, bool clear = true) noexcept { return s.put(clear); }
-//# endif
-
 //# if s.is_derived_type
 //#     filter block_doxygen_comment
     //! @brief Free function accessor for a reference to const /*{s.cpp_name}*/ as a raw, pointer to const /*{s.parent_type}*/ (the base type)
     //! @relates /*{s.cpp_name}*/
     //! @relatesalso /*{s.parent_cpp_type}*/
     //! @ingroup utility_accessors
-//#     endfilter
+//# endfilter
     static OPENXR_HPP_INLINE /*{s.parent_type}*/ const* get_base(/*{s.cpp_name}*/ const& h) {
         return h.get_base();
     }

--- a/scripts/struct.hpp
+++ b/scripts/struct.hpp
@@ -44,8 +44,10 @@
 //#         endif
              , /*{s.next_param_name}*/)
 //#     endif
-//#    for member in visible_members if member.name not in s.parent_fields and not is_static_length_string(member)
+//#    for member in visible_members
+//#       if cpp_hidden_member|length + loop.index > s.parent_fields|length and not is_static_length_string(member)
                   /*{- initializer_comma() }*/ /*{ member.name }*/{/*{ get_default_for_member(member, s.name, "") -}*/}
+//#       endif
 //#    endfor
             {}
 //# endmacro
@@ -68,15 +70,19 @@
 //#        set arg_comma = joiner(",")
               /*{- initializer_comma() }*/ Parent(
                 /*{- arg_comma() -}*/ /*% if s.is_abstract %*/type_ /*% else %*/ /*{- s.struct_type_enum -}*/ /*% endif %*/
-//#        for member in visible_members if member.name in s.parent_fields
+//#        for member in visible_members
+//#           if cpp_hidden_member|length + loop.index <= s.parent_fields|length
                 /*{- arg_comma() }*/ /*{ member.name + "_" -}*/
+//#           endif
 //#        endfor
                 /*{- arg_comma() }*/ /*{ s.next_param_name -}*/
               )
 //#    endif
 
-//#    for member in visible_members if member.name not in s.parent_fields and not is_static_length_array(member)
+//#    for member in visible_members
+//#       if cpp_hidden_member|length + loop.index > s.parent_fields|length and not is_static_length_array(member)
               /*{- initializer_comma() }*/ /*{ member.name }*/ {/*{ member.name + "_"}*/}
+//#       endif
 //#    endfor
         {
 //#    for member in visible_members if is_static_length_array(member)
@@ -206,8 +212,10 @@
         }
 //# endif
 
-//# for member in struct.members if not member is cpp_hidden_member and member.name not in s.parent_fields
+//# for member in struct.members if not member is cpp_hidden_member 
+//#    if loop.index > s.parent_fields|length
         /*{ project_cppdecl(struct, member) }*/;
+//#    endif
 //# endfor
     };
     /*{ wrapperSizeStaticAssert(struct.name, s.cpp_name) }*/

--- a/scripts/struct.hpp
+++ b/scripts/struct.hpp
@@ -115,7 +115,7 @@
     //! @ingroup structs
 //#     endif
 //# endfilter
-    struct XR_MAY_ALIAS /*{ s.cpp_name }*/ /*{ s.struct_parent_decl }*/
+    struct XR_MAY_ALIAS /*{ s.alignas_spec }*/ /*{ s.cpp_name }*/ /*{ s.struct_parent_decl }*/
     {
 //# if s.typed_struct
     private:

--- a/scripts/template_openxr.hpp
+++ b/scripts/template_openxr.hpp
@@ -95,6 +95,7 @@ namespace OPENXR_HPP_NAMESPACE {}  // namespace OPENXR_HPP_NAMESPACE
 
 #include "openxr_atoms.hpp"
 #include "openxr_time.hpp"
+#include "openxr_bool.hpp"
 #include "openxr_version.hpp"
 #include "openxr_dispatch_static.hpp"
 #include "openxr_dispatch_dynamic.hpp"

--- a/scripts/template_openxr_dispatch_dynamic.hpp
+++ b/scripts/template_openxr_dispatch_dynamic.hpp
@@ -40,6 +40,11 @@
 
 #include <openxr/openxr.h>
 
+#if XR_CURRENT_API_VERSION >= XR_MAKE_VERSION(1, 0, 33)
+#define XR_EXTENSION_PROTOTYPES 1
+#include <openxr/openxr_loader_negotiation.h>
+#endif
+
 #ifdef OPENXR_HPP_DOXYGEN
 #include <openxr/openxr_platform.h>
 #endif

--- a/scripts/template_openxr_dispatch_dynamic.hpp
+++ b/scripts/template_openxr_dispatch_dynamic.hpp
@@ -41,7 +41,9 @@
 #include <openxr/openxr.h>
 
 #if XR_CURRENT_API_VERSION >= XR_MAKE_VERSION(1, 0, 33)
+#ifndef XR_EXTENSION_PROTOTYPES
 #define XR_EXTENSION_PROTOTYPES 1
+#endif
 #include <openxr/openxr_loader_negotiation.h>
 #endif
 

--- a/scripts/template_openxr_dispatch_static.hpp
+++ b/scripts/template_openxr_dispatch_static.hpp
@@ -41,6 +41,11 @@
 
 #include <openxr/openxr.h>
 
+#if XR_CURRENT_API_VERSION >= XR_MAKE_VERSION(1, 0, 33)
+#define XR_EXTENSION_PROTOTYPES 1
+#include <openxr/openxr_loader_negotiation.h>
+#endif
+
 #ifdef OPENXR_HPP_DOXYGEN
 #include <openxr/openxr_platform.h>
 #endif

--- a/scripts/template_openxr_dispatch_static.hpp
+++ b/scripts/template_openxr_dispatch_static.hpp
@@ -42,7 +42,9 @@
 #include <openxr/openxr.h>
 
 #if XR_CURRENT_API_VERSION >= XR_MAKE_VERSION(1, 0, 33)
+#ifndef XR_EXTENSION_PROTOTYPES
 #define XR_EXTENSION_PROTOTYPES 1
+#endif
 #include <openxr/openxr_loader_negotiation.h>
 #endif
 

--- a/scripts/template_openxr_enums.hpp
+++ b/scripts/template_openxr_enums.hpp
@@ -44,6 +44,11 @@
 
 #include <openxr/openxr.h>
 
+#if XR_CURRENT_API_VERSION > XR_MAKE_VERSION(1, 0, 32)
+#define XR_EXTENSION_PROTOTYPES 1
+#include <openxr/openxr_loader_negotiation.h>
+#endif
+
 #ifdef OPENXR_HPP_DOXYGEN
 #include <openxr/openxr_platform.h>
 #endif

--- a/scripts/template_openxr_enums.hpp
+++ b/scripts/template_openxr_enums.hpp
@@ -45,7 +45,9 @@
 #include <openxr/openxr.h>
 
 #if XR_CURRENT_API_VERSION > XR_MAKE_VERSION(1, 0, 32)
+#ifndef XR_EXTENSION_PROTOTYPES
 #define XR_EXTENSION_PROTOTYPES 1
+#endif
 #include <openxr/openxr_loader_negotiation.h>
 #endif
 

--- a/scripts/template_openxr_handles.hpp
+++ b/scripts/template_openxr_handles.hpp
@@ -50,6 +50,7 @@
 #include "openxr_handles_forward.hpp"
 #include "openxr_structs_forward.hpp"
 #include "openxr_time.hpp"
+#include "openxr_bool.hpp"
 #include "openxr_dispatch_traits.hpp"
 
 #include <openxr/openxr.h>

--- a/scripts/template_openxr_handles_forward.hpp
+++ b/scripts/template_openxr_handles_forward.hpp
@@ -61,6 +61,10 @@ class DispatchLoaderDynamic;
 // XrSpaceUserIdFB name, and I don't want to make a openxr_spaceuseridfb.hpp file just for this.
 using SpaceUserIdFB = XrSpaceUserIdFB;
 
+// FIXME the only XR_OPAQUE_64 type, may need to be implemented in a real class
+// but this type alias is enought for now
+using FutureEXT = XrFutureEXT;
+
 //# for handle in gen.api_handles
 //## Note this won't actually find anything until automatic_source_generator.py is modified
 //## to actually store a value under "alias" for handles, but...

--- a/scripts/template_openxr_handles_forward.hpp
+++ b/scripts/template_openxr_handles_forward.hpp
@@ -61,10 +61,6 @@ class DispatchLoaderDynamic;
 // XrSpaceUserIdFB name, and I don't want to make a openxr_spaceuseridfb.hpp file just for this.
 using SpaceUserIdFB = XrSpaceUserIdFB;
 
-// FIXME the only XR_OPAQUE_64 type, may need to be implemented in a real class
-// but this type alias is enought for now
-using FutureEXT = XrFutureEXT;
-
 //# for handle in gen.api_handles
 //## Note this won't actually find anything until automatic_source_generator.py is modified
 //## to actually store a value under "alias" for handles, but...

--- a/scripts/template_openxr_method_impls.hpp
+++ b/scripts/template_openxr_method_impls.hpp
@@ -38,8 +38,11 @@
  * @ingroup api_free_functions
  */
 
+#include "openxr_enums.hpp"
+
 #include "openxr_handles.hpp"
 #include "openxr_structs.hpp"
+
 
 
 #include "openxr_method_impls_simple.inl"

--- a/scripts/template_openxr_structs.hpp
+++ b/scripts/template_openxr_structs.hpp
@@ -103,29 +103,45 @@ namespace impl {
         void* next;
     };
     /*{ wrapperSizeStaticAssert('::XrBaseOutStructure', 'OutputStructBase') }*/
-
-    #ifdef _WIN64
-        #pragma pack(push, 4)
-    #endif
-    
-    class XR_MAY_ALIAS FutureCompletionBaseHeaderEXT : public InputStructBase {
-    protected:
-        FutureCompletionBaseHeaderEXT(StructureType type_, void *next_) : InputStructBase(type_, next_) {}
-    
-    public:
-        XrResult futureResult;
-    };
-    
-    #ifdef _WIN64
-        #pragma pack(pop)
-    #endif
-
-    #ifdef _WIN64
-        static_assert(sizeof(FutureCompletionBaseHeaderEXT) == 20);
-    #else
-        static_assert(sizeof(FutureCompletionBaseHeaderEXT) == 24);
-    #endif
 }  // namespace impl
+
+#ifdef XR_EXT_future
+#ifdef _WIN64
+    #pragma pack(push, 4)
+#endif
+/*!
+ * C++ projection of XrFutureCompletionBaseHeaderEXT
+ *
+ * Provided by the `XR_EXT_future` extension.
+ *
+ * @see
+ * <https://www.khronos.org/registry/OpenXR/specs/1.0/html/xrspec.html#XrFutureCompletionBaseHeaderEXT>
+ * @xrentity{XrFutureCompletionBaseHeaderEXT}
+ * @ingroup abstracttypedstructs
+ */
+class XR_MAY_ALIAS FutureCompletionBaseHeaderEXT : public impl::OutputStructBase {
+private:
+    using Parent = impl::OutputStructBase;
+
+protected:
+    //! Protected constructor: this type is abstract.
+    FutureCompletionBaseHeaderEXT(StructureType type_, const Result& futureResult_,
+                                  void* next_ = nullptr)
+        : Parent(type_, next_), futureResult{futureResult_} {}
+
+public:
+    Result futureResult;
+};
+#ifdef _WIN64
+    #pragma pack(pop)
+#endif
+
+#ifdef _WIN64
+    static_assert(sizeof(FutureCompletionBaseHeaderEXT) == 20);
+#else
+    /*{ wrapperSizeStaticAssert('::XrFutureCompletionBaseHeaderEXT', 'FutureCompletionBaseHeaderEXT') }*/
+#endif
+#endif // XR_EXT_future
 
 //# filter block_doxygen_comment
 //! @brief Wrapper for XrEventDataBuffer

--- a/scripts/template_openxr_structs.hpp
+++ b/scripts/template_openxr_structs.hpp
@@ -103,6 +103,28 @@ namespace impl {
         void* next;
     };
     /*{ wrapperSizeStaticAssert('::XrBaseOutStructure', 'OutputStructBase') }*/
+
+    #ifdef _WIN64
+        #pragma pack(push, 4)
+    #endif
+    
+    class XR_MAY_ALIAS FutureCompletionBaseHeaderEXT : public InputStructBase {
+    protected:
+        FutureCompletionBaseHeaderEXT(StructureType type_, void *next_) : InputStructBase(type_, next_) {}
+    
+    public:
+        XrResult futureResult;
+    };
+    
+    #ifdef _WIN64
+        #pragma pack(pop)
+    #endif
+
+    #ifdef _WIN64
+        static_assert(sizeof(FutureCompletionBaseHeaderEXT) == 20);
+    #else
+        static_assert(sizeof(FutureCompletionBaseHeaderEXT) == 24);
+    #endif
 }  // namespace impl
 
 //# filter block_doxygen_comment


### PR DESCRIPTION
Re-enable all skipped extensions/structure/function and fix all compile errors to make the OpenXR-Hpp scripts compatible with the OpenXR-SDK 1.1.51 (see https://github.com/KhronosGroup/OpenXR-Hpp/issues/53).